### PR TITLE
refactor: remove redundant checks in `drawFrame`

### DIFF
--- a/src/Granite.hs
+++ b/src/Granite.hs
@@ -935,14 +935,11 @@ fmt _ _ v
     | otherwise = Text.pack (showFFloat (Just 1) v "")
 
 drawFrame :: Plot -> Text -> Text -> Text
-drawFrame _cfg contentWithAxes legendBlockStr =
+drawFrame cfg contentWithAxes legendBlockStr =
     Text.unlines $
         filter
             (not . Text.null)
-            ( [plotTitle _cfg | not (Text.null (plotTitle _cfg))]
-                <> [contentWithAxes]
-                <> [legendBlockStr | not (Text.null legendBlockStr)]
-            )
+            [plotTitle cfg, contentWithAxes, legendBlockStr]
 
 {- | Evenly spaced tick positions in screen space paired with data values.
   If invertY = True, 0 maps to ymax (top row) and 1 maps to ymin (bottom).


### PR DESCRIPTION
Thanks for this beautiful library!

The `filter` is already handling the not null checks; they seem redundant. Or is this some kind of optimization that I do not understand?

As `_cfg` is used, there's no need for the leading underscore.

