### PR TITLE
Add missing golden test files to cabal file (fixes #17)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,19 +8,20 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250917
+# version: 0.19.20260331
 #
-# REGENDATA ("0.19.20250917",["github","granite.cabal"])
+# REGENDATA ("0.19.20260331",["github","granite.cabal"])
 #
 name: Haskell-CI
 on:
   - push
   - pull_request
   - merge_group
+  - workflow_dispatch
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
@@ -29,9 +30,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.12.2
+          - compiler: ghc-9.12.4
             compilerKind: ghc
-            compilerVersion: 9.12.2
+            compilerVersion: 9.12.4
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.10.3

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -30,6 +30,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.14.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.12.4
             compilerKind: ghc
             compilerVersion: 9.12.4

--- a/granite.cabal
+++ b/granite.cabal
@@ -10,7 +10,7 @@ tested-with:        GHC ==9.4.8
                      || ==9.6.7
                      || ==9.8.4
                      || ==9.10.3
-                     || ==9.12.2
+                     || ==9.12.4
 
 maintainer:         mschavinda@gmail.com
 copyright:          (c) 2024-2025 Michael Chavinda
@@ -18,6 +18,8 @@ bug-reports:        https://github.com/mchav/granite/issues
 category:           Graphics
 build-type:         Simple
 extra-doc-files:    CHANGELOG.md README.md
+extra-source-files: test/golden/*.txt
+                    test/golden/*.svg
 
 source-repository head
   type:     git

--- a/granite.cabal
+++ b/granite.cabal
@@ -11,6 +11,7 @@ tested-with:        GHC ==9.4.8
                      || ==9.8.4
                      || ==9.10.3
                      || ==9.12.4
+                     || ==9.14.1
 
 maintainer:         mschavinda@gmail.com
 copyright:          (c) 2024-2025 Michael Chavinda


### PR DESCRIPTION
The golden test files need to be part of cabal source distribution for the tests to be able to pass in stackage/hackage.

Also I'm taking this opportunity to bump ghc 9.12 to latest patch version and add ghc 9.14.1 to ci config.